### PR TITLE
Add proptest case for fuzzing

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = "1.64.0"
 serde = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]
+proptest = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -6,6 +6,8 @@ mod codepoints;
 mod similar;
 #[cfg(feature = "std")]
 mod string;
+#[cfg(test)]
+mod test;
 mod translation;
 mod util;
 

--- a/core/src/test.rs
+++ b/core/src/test.rs
@@ -1,6 +1,10 @@
 use proptest::prelude::*;
 
 proptest! {
+    // Locally, try running a more exhaustive battery with an environment
+    // variable setting like PROPTEST_CASES=1000000.
+    #![proptest_config(ProptestConfig::with_cases(2000))]
+
     #[test]
     fn character_crash(c in any::<char>(), i in any::<u32>()) {
         let _ = crate::cure_char(c);

--- a/core/src/test.rs
+++ b/core/src/test.rs
@@ -1,0 +1,15 @@
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn character_crash(c in any::<char>(), i in any::<u32>()) {
+        let _ = crate::cure_char(c);
+        let _ = crate::cure_char(i);
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn string_crash(s in "\\PC*") {
+        let _ = crate::cure(&s);
+    }
+}

--- a/core/src/test.rs
+++ b/core/src/test.rs
@@ -17,3 +17,12 @@ proptest! {
         let _ = crate::cure(&s);
     }
 }
+
+#[test]
+fn regression_crash() {
+    let _ = crate::cure_char('Æ');
+    let _ = crate::cure("Æ");
+
+    let _ = crate::cure_char('ˑ');
+    let _ = crate::cure("ˑ");
+}


### PR DESCRIPTION
After looking at the bug reports #4 and #12, I thought that it would make sense to add unicode string fuzzing to decancer. This way unusual edge cases can be randomly generated and any crashes can be detected automatically.

For the default test case quantity, I chose a number which was higher than the default but does not cause any significant delay compared to the overall execution of `cargo test`. However locally running with larger number of test cases can help ensure the robustness of the crate. I have run a few million cases and I have not seen any crashes so far.

I have also added a test to catch regressions for those two previously reported issues. If any new issues are found I would suggest adding those cases to the test.