### PR TITLE
Refactor to use more idiomatic Rust patterns

### DIFF
--- a/core/src/codepoints.rs
+++ b/core/src/codepoints.rs
@@ -12,9 +12,9 @@ pub(crate) const CASE_SENSITIVE_CODEPOINTS_COUNT: u16 =
 pub(crate) const CASE_SENSITIVE_CODEPOINTS_OFFSET: u16 = read_u16_le(CODEPOINTS);
 pub(crate) const CODEPOINTS_COUNT: u16 = ((CASE_SENSITIVE_CODEPOINTS_OFFSET - 6) / 5) - 1;
 
-const CODEPOINT_MASK: u32 = 0x1fffff;
-const RANGE_MASK: u32 = 0x20000000;
-const STRING_TRANSLATION_MASK: u32 = 0x40000000;
+const CODEPOINT_MASK: u32 = 0x001f_ffff;
+const RANGE_MASK: u32 = 0x2000_0000;
+const STRING_TRANSLATION_MASK: u32 = 0x4000_0000;
 
 pub(crate) struct Codepoint(u32, u8);
 

--- a/core/src/codepoints.rs
+++ b/core/src/codepoints.rs
@@ -29,29 +29,25 @@ impl Codepoint {
   }
 
   pub(crate) const fn matches(&self, other: u32) -> Ordering {
-    let conf: u32 = self.0 & CODEPOINT_MASK;
+    let mut conf: u32 = self.0 & CODEPOINT_MASK;
 
     if other < conf {
       return Ordering::Less;
     }
 
-    let mut max = conf;
-
     if (self.0 & RANGE_MASK) != 0 {
-      max += (self.1 & 0x7f) as u32;
+      conf += (self.1 & 0x7f) as u32;
     }
 
-    if other > max {
-      Ordering::Greater
-    } else {
-      Ordering::Equal
+    if other > conf {
+      return Ordering::Greater;
     }
+
+    Ordering::Equal
   }
 
   pub(crate) const fn translation(&self, other: u32) -> Translation {
-    if (self.0 & STRING_TRANSLATION_MASK) != 0 {
-      Translation::string(self.0, self.1)
-    } else {
+    if (self.0 & STRING_TRANSLATION_MASK) == 0 {
       let mut code = (self.0 >> 21) & 0xff;
 
       if code == 0 {
@@ -60,7 +56,9 @@ impl Codepoint {
         code += other - (self.0 & CODEPOINT_MASK);
       }
 
-      Translation::character(code)
+      return Translation::character(code);
     }
+
+    Translation::string(self.0, self.1)
   }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -31,7 +31,7 @@ const fn translate(code: u32, offset: i32, mut end: i32) -> Option<Translation> 
     match codepoint.matches(code) {
       Ordering::Equal => return Some(codepoint.translation(code)),
       Ordering::Greater => start = mid + 1,
-      _ => end = mid - 1,
+      Ordering::Less => end = mid - 1,
     };
   }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -74,7 +74,7 @@ const fn translate(code: u32, offset: i32, mut end: i32) -> Option<Translation> 
 pub fn cure_char<C: Into<u32>>(code: C) -> Translation {
   let code = code.into();
 
-  if code <= 31 || code == 127 || (0xd800..=0xf8ff).contains(&code) || code >= 0xe0100 {
+  if matches!(code, 0..=31 | 127 | 0xd800..=0xf8ff | 0xe0100..) {
     return Translation::None;
   }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -98,7 +98,7 @@ pub fn cure_char<C: Into<u32>>(code: C) -> Translation {
   }
 
   translate(code_lowercased, 6, CODEPOINTS_COUNT as _)
-    .unwrap_or(Translation::character(code_lowercased))
+    .unwrap_or_else(|| Translation::character(code_lowercased))
 }
 
 /// Cures a string.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -71,10 +71,7 @@ const fn translate(code: u32, offset: i32, mut end: i32) -> Option<Translation> 
 ///
 /// assert!(matches!(cured_surrogate, Translation::None));
 /// ```
-pub fn cure_char<C>(code: C) -> Translation
-where
-  C: Into<u32>,
-{
+pub fn cure_char<C: Into<u32>>(code: C) -> Translation {
   let code = code.into();
 
   if code <= 31 || code == 127 || (0xd800..=0xf8ff).contains(&code) || code >= 0xe0100 {

--- a/core/src/similar.rs
+++ b/core/src/similar.rs
@@ -6,45 +6,45 @@ pub(crate) const SIMILAR_END: u16 = read_u16_le(unsafe { CODEPOINTS.offset(4) })
 pub(crate) fn is(self_char: u32, other_char: char) -> bool {
   let other_char = unsafe { other_char.to_lowercase().next().unwrap_unchecked() as u32 };
 
-  if self_char != other_char {
-    if self_char <= 0x7f && other_char <= 0x7f {
-      let mut offset = SIMILAR_START;
-      let mut contains_a = false;
-      let mut contains_b = false;
+  if self_char == other_char {
+    return true;
+  }
 
-      loop {
-        let cur = unsafe { *(CODEPOINTS.offset(offset as _)) };
-        let sim = cur & 0x7f;
+  if self_char <= 0x7f && other_char <= 0x7f {
+    let mut offset = SIMILAR_START;
+    let mut contains_a = false;
+    let mut contains_b = false;
 
-        if sim == (self_char as u8) {
-          contains_a = true;
-        }
+    loop {
+      let cur = unsafe { *(CODEPOINTS.offset(offset as _)) };
+      let sim = cur & 0x7f;
 
-        if sim == (other_char as u8) {
-          contains_b = true;
-        }
+      if sim == (self_char as u8) {
+        contains_a = true;
+      }
 
-        if contains_a && contains_b {
-          return true;
-        }
+      if sim == (other_char as u8) {
+        contains_b = true;
+      }
 
-        if cur >= 0x80 {
-          contains_a = false;
-          contains_b = false;
-        }
+      if contains_a && contains_b {
+        return true;
+      }
 
-        offset += 1;
+      if cur >= 0x80 {
+        contains_a = false;
+        contains_b = false;
+      }
 
-        if offset == SIMILAR_END {
-          return false;
-        }
+      offset += 1;
+
+      if offset == SIMILAR_END {
+        return false;
       }
     }
-
-    false
-  } else {
-    true
   }
+
+  false
 }
 
 #[inline(always)]

--- a/core/src/string.rs
+++ b/core/src/string.rs
@@ -138,7 +138,7 @@ impl Extend<CuredString> for String {
   where
     I: IntoIterator<Item = CuredString>,
   {
-    self.extend(iter.into_iter().map(|s| s.into_str()))
+    self.extend(iter.into_iter().map(CuredString::into_str));
   }
 }
 

--- a/core/src/translation.rs
+++ b/core/src/translation.rs
@@ -79,7 +79,7 @@ where
       }
 
       Self::String(s) => s.len() == o.len() && similar::is_str(s, o),
-      _ => o.is_empty(),
+      Self::None => o.is_empty(),
     }
   }
 }
@@ -90,7 +90,7 @@ impl Display for Translation {
     match self {
       Self::Character(ch) => Display::fmt(ch, f),
       Self::String(s) => Display::fmt(s, f),
-      _ => Ok(()),
+      Self::None => Ok(()),
     }
   }
 }
@@ -107,7 +107,7 @@ impl Extend<Translation> for String {
       match part {
         Translation::Character(c) => self.push(c),
         Translation::String(s) => self.push_str(s),
-        _ => {}
+        Translation::None => {}
       }
     }
   }


### PR DESCRIPTION
I thought I'd help contribute to the crate some more, since I'm using it for an application and it doesn't seem to get frequent contributions despite its high quality and utility.

This PR helps to refactor some code to use more idiomatic Rust patterns. Some of these are more opinionated than others, so feel free to comment on any you don't think are appropriate:

* Restructures some control flow to remove unnecessary `else` statements or check negations.
* Removes wildcards that match to one statement (which helps reduce some cognitive overhead).
* Changes a series of if statements on the same variable to a `matches!` statement, which is cleaner and slightly improves speed.
* Changes an instance of `unwrap_or()` to `unwrap_or_else()` (which doesn't compute the enclosed value unless needed).
* Removes an unnecessary closure.
* Removes an unnecessary binding.
* Removes a "where" statement that can be written more concisely.
* Adds underscores to masks to improve readability.

Additionally, I do have some further questions/comments about the crate that I couldn't address myself:
* The use of unsafe methods in this crate are quite masterful, though as good practice it would be nice to comment the invariants that are assumed for each block. I couldn't figure out what some of the unsafe blocks were doing (particularly in regards to the pointer arithmetic), so I wasn't able to do this myself.
  * As an aside, the optimizations in the unsafe blocks _do_ improve the speed, but on the scale of around 20-70 ms per 10,000,000 iterations (which I don't think this crate will be dealing with often) from what I've been able to test. While normally I'd go with the safe option to avoid invariants in the code, I assume the purpose of these unsafe blocks were to optimize for speed as much as possible, so I haven't suggested removing them despite there also being fast safe alternatives for many operations.
* The `into_str()` method in the module `string` seems to have a few peculiarities:
  * Despite being named `into_str()`, it returns a `String`. Since `str` is its own data type, this could lead to some confusion.
  * This method uses `std::mem::transmute()` to transform a `CuredString(String)` into just a `String`. This method could instead just return the inner value by doing `self.0`. From what I can gather, any speed difference (if it exists) is negligible. The only drawback to this is that the function would not be `const` anymore, though I'm not sure when this would be used in `const` contexts as `cure` is not `const`.
* It could be worthwhile to create some benchmarks to test future code performance changes, as right now my benchmarks are more ad hoc and not fit for production. If you'd like, I could try looking into this to add it to the crate.

I appreciate all the work you've done with this crate, and I hope that these contributions are helpful!