### PR TITLE
Add Basic Benchmarking

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,6 +19,12 @@ serde = { version = "1", default-features = false, optional = true }
 proptest = { version = "1", default-features = false, features = ["std"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+criterion = "0.5"
+rand = "0.8"
+
+[[bench]]
+name = "decancer_bench"
+harness = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/core/benches/decancer_bench.rs
+++ b/core/benches/decancer_bench.rs
@@ -2,13 +2,19 @@ use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use decancer::{cure, cure_char};
 use rand::{thread_rng, Rng};
 
+fn cure_short(c: &mut Criterion) {
+    let input = String::from("vＥⓡ𝔂 𝔽𝕌Ňℕｙ ţ乇𝕏𝓣");
+  
+    c.bench_function("cure short input", |b| b.iter(|| cure(&input)));
+  }
+
 fn cure_random(c: &mut Criterion) {
-  c.bench_function("cure random batch", |b| {
+  c.bench_function("cure random input", |b| {
     b.iter_batched(
       || {
         thread_rng()
           .sample_iter::<char, _>(rand::distributions::Standard)
-          .take(100)
+          .take(500)
           .collect::<String>()
       },
       |key| cure(&key),
@@ -18,7 +24,7 @@ fn cure_random(c: &mut Criterion) {
 }
 
 fn cure_char_random(c: &mut Criterion) {
-  c.bench_function("cure_char random batch", |b| {
+  c.bench_function("cure_char random input", |b| {
     b.iter_batched(
       || {
         thread_rng()
@@ -32,23 +38,10 @@ fn cure_char_random(c: &mut Criterion) {
   });
 }
 
-fn cure_speed(c: &mut Criterion) {
-  let input = String::from("vＥⓡ𝔂 𝔽𝕌Ňℕｙ ţ乇𝕏𝓣");
-
-  c.bench_function("cure speed", |b| b.iter(|| cure(&input)));
-}
-
-fn cure_char_speed(c: &mut Criterion) {
-  let input = '✅';
-
-  c.bench_function("cure_char speed", |b| b.iter(|| cure_char(input)));
-}
-
 criterion_group!(
   benches,
-  cure_speed,
+  cure_short,
   cure_random,
-  cure_char_speed,
   cure_char_random,
 );
 criterion_main!(benches);

--- a/core/benches/decancer_bench.rs
+++ b/core/benches/decancer_bench.rs
@@ -1,24 +1,19 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use decancer::{cure, cure_char};
-use rand::{thread_rng, Rng};
+use rand::random;
 
 /// Tests the speed of curing a short constant `String`.
 fn cure_short(c: &mut Criterion) {
-    let input = String::from("vＥⓡ𝔂 𝔽𝕌Ňℕｙ ţ乇𝕏𝓣");
-  
-    c.bench_function("cure short input", |b| b.iter(|| cure(&input)));
-  }
+  let input = String::from("vＥⓡ𝔂 𝔽𝕌Ňℕｙ ţ乇𝕏𝓣");
+
+  c.bench_function("cure short input", |b| b.iter(|| cure(&input)));
+}
 
 /// Tests the speed of curing a random input `String` with 500 characters.
 fn cure_random(c: &mut Criterion) {
   c.bench_function("cure random input", |b| {
     b.iter_batched(
-      || {
-        thread_rng()
-          .sample_iter::<char, _>(rand::distributions::Standard)
-          .take(500)
-          .collect::<String>()
-      },
+      || String::from_iter([random::<char>(); 500].iter()),
       |key| cure(&key),
       BatchSize::SmallInput,
     )
@@ -28,23 +23,9 @@ fn cure_random(c: &mut Criterion) {
 /// Tests the speed of curing indvidual random characters using `cure_char`.
 fn cure_char_random(c: &mut Criterion) {
   c.bench_function("cure_char random input", |b| {
-    b.iter_batched(
-      || {
-        thread_rng()
-          .sample_iter::<char, _>(rand::distributions::Standard)
-          .next()
-          .unwrap()
-      },
-      cure_char,
-      BatchSize::SmallInput,
-    )
+    b.iter_batched(|| random::<char>(), cure_char, BatchSize::SmallInput)
   });
 }
 
-criterion_group!(
-  benches,
-  cure_short,
-  cure_random,
-  cure_char_random,
-);
+criterion_group!(benches, cure_short, cure_random, cure_char_random,);
 criterion_main!(benches);

--- a/core/benches/decancer_bench.rs
+++ b/core/benches/decancer_bench.rs
@@ -1,0 +1,54 @@
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use decancer::{cure, cure_char};
+use rand::{thread_rng, Rng};
+
+fn cure_random(c: &mut Criterion) {
+  c.bench_function("cure_random", |b| {
+    b.iter_batched(
+      || {
+        thread_rng()
+          .sample_iter::<char, _>(rand::distributions::Standard)
+          .take(100)
+          .collect::<String>()
+      },
+      |key| cure(&key),
+      BatchSize::SmallInput,
+    )
+  });
+}
+
+fn cure_char_random(c: &mut Criterion) {
+  c.bench_function("cure_char_random", |b| {
+    b.iter_batched(
+      || {
+        thread_rng()
+          .sample_iter::<char, _>(rand::distributions::Standard)
+          .next()
+          .unwrap()
+      },
+      cure_char,
+      BatchSize::SmallInput,
+    )
+  });
+}
+
+fn cure_speed(c: &mut Criterion) {
+  let input = String::from("vＥⓡ𝔂 𝔽𝕌Ňℕｙ ţ乇𝕏𝓣");
+
+  c.bench_function("cure_speed", |b| b.iter(|| cure(&input)));
+}
+
+fn cure_char_speed(c: &mut Criterion) {
+  let input = '✅';
+
+  c.bench_function("cure_char_speed", |b| b.iter(|| cure_char(input)));
+}
+
+criterion_group!(
+  benches,
+  cure_random,
+  cure_char_random,
+  cure_speed,
+  cure_char_speed
+);
+criterion_main!(benches);

--- a/core/benches/decancer_bench.rs
+++ b/core/benches/decancer_bench.rs
@@ -3,7 +3,7 @@ use decancer::{cure, cure_char};
 use rand::{thread_rng, Rng};
 
 fn cure_random(c: &mut Criterion) {
-  c.bench_function("cure_random", |b| {
+  c.bench_function("cure random batch", |b| {
     b.iter_batched(
       || {
         thread_rng()
@@ -18,7 +18,7 @@ fn cure_random(c: &mut Criterion) {
 }
 
 fn cure_char_random(c: &mut Criterion) {
-  c.bench_function("cure_char_random", |b| {
+  c.bench_function("cure_char random batch", |b| {
     b.iter_batched(
       || {
         thread_rng()
@@ -35,20 +35,20 @@ fn cure_char_random(c: &mut Criterion) {
 fn cure_speed(c: &mut Criterion) {
   let input = String::from("vＥⓡ𝔂 𝔽𝕌Ňℕｙ ţ乇𝕏𝓣");
 
-  c.bench_function("cure_speed", |b| b.iter(|| cure(&input)));
+  c.bench_function("cure speed", |b| b.iter(|| cure(&input)));
 }
 
 fn cure_char_speed(c: &mut Criterion) {
   let input = '✅';
 
-  c.bench_function("cure_char_speed", |b| b.iter(|| cure_char(input)));
+  c.bench_function("cure_char speed", |b| b.iter(|| cure_char(input)));
 }
 
 criterion_group!(
   benches,
-  cure_random,
-  cure_char_random,
   cure_speed,
-  cure_char_speed
+  cure_random,
+  cure_char_speed,
+  cure_char_random,
 );
 criterion_main!(benches);

--- a/core/benches/decancer_bench.rs
+++ b/core/benches/decancer_bench.rs
@@ -2,12 +2,14 @@ use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use decancer::{cure, cure_char};
 use rand::{thread_rng, Rng};
 
+/// Tests the speed of curing a short constant `String`.
 fn cure_short(c: &mut Criterion) {
     let input = String::from("vＥⓡ𝔂 𝔽𝕌Ňℕｙ ţ乇𝕏𝓣");
   
     c.bench_function("cure short input", |b| b.iter(|| cure(&input)));
   }
 
+/// Tests the speed of curing a random input `String` with 500 characters.
 fn cure_random(c: &mut Criterion) {
   c.bench_function("cure random input", |b| {
     b.iter_batched(
@@ -23,6 +25,7 @@ fn cure_random(c: &mut Criterion) {
   });
 }
 
+/// Tests the speed of curing indvidual random characters using `cure_char`.
 fn cure_char_random(c: &mut Criterion) {
   c.bench_function("cure_char random input", |b| {
     b.iter_batched(


### PR DESCRIPTION
This PR adds some benchmarking to the crate to measure the speed of both `cure` and `cure_char`. It should help with checking if future changes improve or regress performance.

I don't have _much_ experience with using Criterion, but thus far it seems to work well. As with benchmarking in general, it's susceptible to noise (especially as a statistics-based brenchmarking crate), so it's recommended to run `cargo bench` without doing things in the background. Thankfully, it can be used perfectly fine on stable (the benefit of using Criterion).