### PR TITLE
Fix spelling of 'its' for the possessive form

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,13 +51,13 @@ interface JsonContents {
 
   - The `JsonContents#codepoints` array **must NOT be empty.** _(duh)_
   - `Codepoint#codepoint` is the unicode codepoint. It must be around `\u80` to `\ue00ff` and must NOT be a [surrogate](https://en.wikipedia.org/wiki/Universal_Character_Set_characters#Surrogates).
-  - `Codepoint#translation` is the translation string, it's length must not exceed `15`, it must be in lowercase, and it must be in ASCII.
+  - `Codepoint#translation` is the translation string: its length must not exceed `15`, it must be in lowercase, and it must be in ASCII.
   - `Codepoint#rangeUntil` is an optional number that indicates where the range of this codepoint should end. If it's `null`, then the codepoint is not a range. For example: Say a codepoint with the codepoints of `\xE0` to `\xE5` all translates to `a`, then the `codepoint` field would be `0x00EO` and the `rangeUntil` field would be `0x00E5`. **Please note that the range size MUST be around `1` to `127`.**
   - `Codepoint#syncedTranslation` is a flag whether this range's translation would change accordingly with the codepoint index. For example: `\xE0` translates to `a`, `\xE1` translates to `b`, `\xE2` translates to `c`, and so on (the translation property's length must be `1`).
 
 - **Information regarding the `JsonContents#similar` field:**
 
-  - The `string[][]` two-dimensional array **must NOT be empty** and it's length **must NOT exceed `127`.**
+  - The `string[][]` two-dimensional array **must NOT be empty** and its length **must NOT exceed `127`.**
   - The `string[]` arrays **must NOT be empty** and their lengths **must NOT exceed `255`.**
   - Each `string` **must ONLY be only one character in length.**
   - Each `string` **must ONLY be in the ASCII range.**

--- a/core/README.md
+++ b/core/README.md
@@ -33,9 +33,9 @@
 
 A tiny package that removes common unicode confusables/homoglyphs from strings.
 
-- It's core is written in [Rust](https://www.rust-lang.org) and utilizes a form of **Binary Search** to ensure speed!
+- Its core is written in [Rust](https://www.rust-lang.org) and utilizes a form of **Binary Search** to ensure speed!
 - It virtually has **no third-party dependencies** - it only depends on itself.
-- It stores it's huge collection of codepoints in an [optimized 25.72 KB binary file](https://github.com/null8626/decancer/blob/main/core/bin/codepoints.bin) instead of a huge JSON or text file to optimize it's bundle size!
+- It stores its huge collection of codepoints in an [optimized 25.72 KB binary file](https://github.com/null8626/decancer/blob/main/core/bin/codepoints.bin) instead of a huge JSON or text file to optimize its bundle size!
 - It's capable of filtering **149,513 (13.42%) different unicode codepoints** including **9,628 different confusables**, like:
   - All [whitespace characters](https://en.wikipedia.org/wiki/Whitespace_character)
   - All [diacritics](https://en.wikipedia.org/wiki/Diacritic), this also eliminates all forms of [Zalgo text](https://en.wikipedia.org/wiki/Zalgo_text)
@@ -253,7 +253,7 @@ int main(void) {
     assert(decancer_equals(cured, (uint8_t *)("very funny text"), 15), "equals");
     assert(decancer_contains(cured, (uint8_t *)("funny"), 5), "contains");
 
-    // coerce output as a raw UTF-8 pointer and retrieve it's size (in bytes)
+    // coerce output as a raw UTF-8 pointer and retrieve its size (in bytes)
     size_t output_size;
     const uint8_t *output_raw = decancer_raw(cured, &output_size);
 


### PR DESCRIPTION
It's means "it is", but "its" means "belonging to it". Reference: https://www.merriam-webster.com/grammar/when-to-use-its-vs-its